### PR TITLE
More tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# OxWM
+
+OxWM is the Oxidized Window Manager, a minimal X11 window manager written in Rust.
+
 # Getting Started
 
 You might want to have a file named `oxwm/config.toml` in your platform-specific
@@ -18,8 +22,8 @@ q = "kill"
 This tells OxWM that `mod4` is the global modifier key, that OxWM should run
 `konsole` on startup, and that it should use a click-to-focus model. It also
 tells OxWM that, with the modifier key pressed, pressing the `Escape` key should
-exit, and pressing `q` should immediately abort the process of the focused
-window.
+exit, and pressing `q` should close the focused window, or immediately abort the
+process of the focused window if it cannot be closed.
 
 If you don't create this config file, one will be generated for you at the
 appropriate location.
@@ -54,7 +58,8 @@ it.
 Due to the nature of the program, very little automated testing is possible (as
 far as we know). In theory, it should be possible to create a "mock" X
 connection and drive it programmatically, but this would be a substantial
-undertaking.
+undertaking. Unit tests, as far as are possible without a functioning X connection,
+have been implemented for the `Clients` and `Config` types.
 
 # Future directions
 
@@ -65,3 +70,8 @@ abstractions, and fixing things will probably require a rewrite. This is not a
 crazy suggestion, since we didn't know anything about the X protocol when we
 started; knowing much more now, it should be easier to create a sound design
 from the start.
+
+# Authors
+
+* Nicholas Coltharp
+* James Nichols

--- a/src/client.rs
+++ b/src/client.rs
@@ -109,19 +109,16 @@ impl Clients {
 
     /// Indicates whether a client corresponding to the given window exists.
     pub(crate) fn has_client(&self, window: xproto::Window) -> bool {
-        self.stack
-            .iter()
-            .find(|client| client.window == window)
-            .is_some()
+        self.stack.iter().any(|client| client.window == window)
     }
 
     /// Get an iterator over the stack, from bottom to top.
-    pub(crate) fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = &'a Client> {
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = &Client> {
         self.stack.iter()
     }
 
     /// Get an iterator over the stack, from bottom to top.
-    pub(crate) fn iter_mut<'a>(&'a mut self) -> impl DoubleEndedIterator<Item = &'a mut Client> {
+    pub(crate) fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Client> {
         self.stack.iter_mut()
     }
 
@@ -181,7 +178,7 @@ impl Clients {
     }
 
     /// Move a client to just above another one.
-    pub(crate) fn to_above(&mut self, window: xproto::Window, sibling: xproto::Window) {
+    pub(crate) fn move_to_above(&mut self, window: xproto::Window, sibling: xproto::Window) {
         let (i, _) = self.get_with_index(window);
         if i > 0 && self.stack[i - 1].window == sibling {
             return;
@@ -192,7 +189,7 @@ impl Clients {
     }
 
     /// Lower a client to the bottom of the stack.
-    pub(crate) fn to_bottom(&mut self, window: xproto::Window) {
+    pub(crate) fn move_to_bottom(&mut self, window: xproto::Window) {
         if self.stack.first().unwrap().window == window {
             return;
         }
@@ -203,7 +200,7 @@ impl Clients {
 
     /// Raise a client to the top of the stack.
     #[allow(dead_code)]
-    pub(crate) fn to_top(&mut self, window: xproto::Window) {
+    pub(crate) fn move_to_top(&mut self, window: xproto::Window) {
         if self.top().window == window {
             return;
         }
@@ -418,7 +415,7 @@ fn check_client_stacking() {
     assert_eq!(clients.has_client(300), false);
     assert_eq!(clients.has_client(675), false);
 
-    clients.to_above(100, 250);
+    clients.move_to_above(100, 250);
     //150,200,250,100
     assert_eq!(clients.top().window, 100);
     assert_eq!(clients.top_mut().window, 100);
@@ -428,12 +425,12 @@ fn check_client_stacking() {
     assert_eq!(clients.top().window, 250);
     assert_eq!(clients.top_mut().window, 250);
 
-    clients.to_top(150);
+    clients.move_to_top(150);
     //200,250,150
     assert_eq!(clients.top().window, 150);
     assert_eq!(clients.top_mut().window, 150);
 
-    clients.to_bottom(250);
+    clients.move_to_bottom(250);
     //250,200,150
     {
         let mut iter = clients.iter();
@@ -445,7 +442,7 @@ fn check_client_stacking() {
     assert_eq!(clients.top().window, 150);
     assert_eq!(clients.top_mut().window, 150);
 
-    clients.to_above(150, 250);
+    clients.move_to_above(150, 250);
     //250,150,200
     {
         let mut iter = clients.iter();
@@ -455,7 +452,7 @@ fn check_client_stacking() {
         assert_eq!(iter.next(), None);
     }
 
-    clients.to_above(150, 200);
+    clients.move_to_above(150, 200);
     //250,200,150
     {
         let mut iter = clients.iter();
@@ -465,7 +462,7 @@ fn check_client_stacking() {
         assert_eq!(iter.next(), None);
     }
 
-    clients.to_above(250, 150);
+    clients.move_to_above(250, 150);
     //200,150,250?
     {
         let mut iter = clients.iter();

--- a/src/client.rs
+++ b/src/client.rs
@@ -244,7 +244,11 @@ impl Clients {
     }
 }
 
-/// Tests.
+/// Issue was encountered where `Clients` could retain the ID of a closed window in
+/// `Clients.focus`, despite having removed the corresponding window from the stack
+/// of managed windows. This caused an "unwrap None" error on removing the next window.
+/// Regression test to verify that `Clients.remove` properly updates `Clients.focus` when
+/// the focused window is removed.
 #[test]
 fn can_remove_focused_window() {
     let mut clients = Clients {
@@ -252,6 +256,7 @@ fn can_remove_focused_window() {
         focus: None,
     };
 
+    //Setup dummy clients in the absence of an X11 server
     clients.push(Client {
         window: 100,
         state: Some(ClientState {
@@ -306,17 +311,243 @@ fn can_remove_focused_window() {
 
     clients.set_focus(300);
     assert_eq!(clients.get_focus().unwrap().window, 300);
+    assert_eq!(clients.get_focus_mut().unwrap().window, 300);
 
     clients.remove(100);
     assert_eq!(clients.get_focus().unwrap().window, 300);
+    assert_eq!(clients.get_focus_mut().unwrap().window, 300);
 
     clients.remove(300);
     assert!(clients.get_focus().is_none());
+    assert!(clients.get_focus_mut().is_none());
 
     clients.set_focus(200);
     clients.remove(250);
     assert_eq!(clients.get_focus().unwrap().window, 200);
+    assert_eq!(clients.get_focus_mut().unwrap().window, 200);
 
     clients.remove(200);
     assert!(clients.get_focus().is_none());
+    assert!(clients.get_focus_mut().is_none());
+}
+
+/// Confirm that window stack positioning operations have correct behavior
+#[test]
+fn check_client_stacking() {
+    let mut clients = Clients {
+        stack: vec![],
+        focus: None,
+    };
+
+    //Setup dummy clients in the absence of an X11 server
+    clients.push(Client {
+        window: 100,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    clients.push(Client {
+        window: 150,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    clients.push(Client {
+        window: 200,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    clients.push(Client {
+        window: 250,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: false,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    clients.push(Client {
+        window: 300,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    //100,150,200,250,300
+    assert_eq!(clients.top().window, 300);
+    assert_eq!(clients.top_mut().window, 300);
+    assert_eq!(clients.has_client(300), true);
+    assert_eq!(clients.has_client(675), false);
+
+    clients.remove(300);
+    //100,150,200,250
+    assert_eq!(clients.top().window, 250);
+    assert_eq!(clients.top_mut().window, 250);
+    assert_eq!(clients.has_client(300), false);
+    assert_eq!(clients.has_client(675), false);
+
+    clients.to_above(100, 250);
+    //150,200,250,100
+    assert_eq!(clients.top().window, 100);
+    assert_eq!(clients.top_mut().window, 100);
+
+    clients.remove(100);
+    //150,200,250
+    assert_eq!(clients.top().window, 250);
+    assert_eq!(clients.top_mut().window, 250);
+
+    clients.to_top(150);
+    //200,250,150
+    assert_eq!(clients.top().window, 150);
+    assert_eq!(clients.top_mut().window, 150);
+
+    clients.to_bottom(250);
+    //250,200,150
+    {
+        let mut iter = clients.iter();
+        assert_eq!(iter.next().unwrap().window, 250);
+        assert_eq!(iter.next().unwrap().window, 200);
+        assert_eq!(iter.next().unwrap().window, 150);
+        assert_eq!(iter.next(), None);
+    }
+    assert_eq!(clients.top().window, 150);
+    assert_eq!(clients.top_mut().window, 150);
+
+    clients.to_above(150, 250);
+    //250,150,200
+    {
+        let mut iter = clients.iter();
+        assert_eq!(iter.next().unwrap().window, 250);
+        assert_eq!(iter.next().unwrap().window, 150);
+        assert_eq!(iter.next().unwrap().window, 200);
+        assert_eq!(iter.next(), None);
+    }
+
+    clients.to_above(150, 200);
+    //250,200,150
+    {
+        let mut iter = clients.iter();
+        assert_eq!(iter.next().unwrap().window, 250);
+        assert_eq!(iter.next().unwrap().window, 200);
+        assert_eq!(iter.next().unwrap().window, 150);
+        assert_eq!(iter.next(), None);
+    }
+
+    clients.to_above(250, 150);
+    //200,150,250?
+    {
+        let mut iter = clients.iter();
+        assert_eq!(iter.next().unwrap().window, 200);
+        assert_eq!(iter.next().unwrap().window, 150);
+        assert_eq!(iter.next().unwrap().window, 250);
+        assert_eq!(iter.next(), None);
+    }
+}
+
+/// Confirm that the get and get_mut functions retrieve the expected Client.
+#[test]
+fn check_get() {
+    let mut clients = Clients {
+        stack: vec![],
+        focus: None,
+    };
+
+    //Setup dummy clients in the absence of an X11 server
+    clients.push(Client {
+        window: 100,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    clients.push(Client {
+        window: 150,
+        state: Some(ClientState {
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 10,
+            is_viewable: true,
+            wm_protocols: WmProtocols::new(),
+            wm_state: None,
+        }),
+    });
+
+    assert_eq!(clients.get(100).window, 100);
+    assert_eq!(clients.get_mut(100).window, 100);
+    assert_eq!(clients.get(150).window, 150);
+    assert_eq!(clients.get_mut(150).window, 150);
+
+    // At this time it is an error to attempt an operation on a window ID that does
+    // not have a corresponding Client.
+    let panic_result = std::panic::catch_unwind(|| assert_eq!(clients.get(750).window, 150));
+    assert!(panic_result.is_err());
+
+    // Here `AssertUnwindSafe` is used to confirm that `Clients.get_mut()` will panic
+    // when passed a window ID for which it has no corresponding client. As this
+    // means a mutable borrow is transferred beyond an unwind boundary we cannot
+    // assure that `clients_unsafe` is in a good state after the panic so it should
+    // be dropped immediately.
+    {
+        let mut clients_unsafe = Clients {
+            stack: vec![],
+            focus: None,
+        };
+
+        //Setup dummy clients in the absence of an X11 server
+        clients_unsafe.push(Client {
+            window: 100,
+            state: Some(ClientState {
+                x: 1,
+                y: 1,
+                width: 10,
+                height: 10,
+                is_viewable: true,
+                wm_protocols: WmProtocols::new(),
+                wm_state: None,
+            }),
+        });
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assert_eq!(clients_unsafe.get_mut(750).window, 150);
+        }));
+        assert!(panic_result.is_err());
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,8 +236,8 @@ impl<Conn> Config<Conn> {
         // Config object's translate_keybinds method to populate keybinds before use.
         let keybinds = HashMap::new();
         let mut keybind_names: HashMap<String, String> = HashMap::new();
-        keybind_names.insert("q".to_string(), "quit".to_string());
-        keybind_names.insert("w".to_string(), "kill".to_string());
+        keybind_names.insert("Escape".to_string(), "quit".to_string());
+        keybind_names.insert("q".to_string(), "kill".to_string());
         Self {
             startup,
             mod_mask,
@@ -288,7 +288,7 @@ impl<Conn> Config<Conn> {
 /// Errors relating to finding invalid but properly formed `Config.toml` contents.
 #[derive(PartialEq, Eq, Clone, Debug, Error)]
 pub(crate) enum ConfigError {
-    #[error("Unrecodgnized key \"{0}\" in your Config.toml")]
+    #[error("Unrecognized key \"{0}\" in your Config.toml")]
     KeysymError(String),
     #[error("X11 server does not have a Keycode assigned for \"{0}\" (Keysym: {1:#x})\nThis key may not be available in your current keyboard layout.")]
     KeycodeError(String, xproto::Keysym),
@@ -334,14 +334,14 @@ fn check_deserialize_defaults() {
     assert_eq!(a_config.startup, vec!["xterm"]);
     assert_eq!(a_config.mod_mask, xproto::ModMask::M4);
     assert_eq!(a_config.focus_model, FocusModel::Click);
-    assert!(a_config.keybind_names.contains_key("w"));
-    assert_eq!(a_config.keybind_names["w"], "kill");
     assert!(a_config.keybind_names.contains_key("q"));
-    assert_eq!(a_config.keybind_names["q"], "quit");
+    assert_eq!(a_config.keybind_names["q"], "kill");
+    assert!(a_config.keybind_names.contains_key("Escape"));
+    assert_eq!(a_config.keybind_names["Escape"], "quit");
     assert_eq!(a_config.keybind_names.len(), 2);
 
     let partial_toml =
-        "startup = [\"xterm\", \"xclock\"]\n[keybinds]\nF4 = \"kill\"\nEscape = \"quit\"\n";
+        "startup = [\"xterm\", \"xclock\"]\n[keybinds]\nF4 = \"kill\"\nq = \"quit\"\n";
     let response: std::result::Result<
         Config<x11rb::rust_connection::RustConnection>,
         toml::de::Error,
@@ -353,8 +353,8 @@ fn check_deserialize_defaults() {
     assert_eq!(a_config.focus_model, FocusModel::Click); // from defaults
     assert!(a_config.keybind_names.contains_key("F4"));
     assert_eq!(a_config.keybind_names["F4"], "kill");
-    assert!(a_config.keybind_names.contains_key("Escape"));
-    assert_eq!(a_config.keybind_names["Escape"], "quit");
+    assert!(a_config.keybind_names.contains_key("q"));
+    assert_eq!(a_config.keybind_names["q"], "quit");
     assert_eq!(a_config.keybind_names.len(), 2);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -640,12 +640,20 @@ impl<Conn> OxWM<Conn> {
     // Actions go here. Note that, due to the need to conform to the Action
     // type, these functions' type signatures may sometimes seem odd.
 
-    /// Kill the currently-focused client.
+    /// Kill the currently moused-over client.
     fn kill_focused_client(&mut self, window: xproto::Window) -> Result<()>
     where
         Conn: Connection,
     {
-        self.kill(window)
+        //X11 server sends window id of the window underneath the mouse cursor in
+        //response to our bound keypress events. If the mouse is over the desktop
+        //background the id we receive is 0. Ignore attempts to kill non-existant
+        //windows.
+        if 0 != window {
+            self.kill(window)
+        } else {
+            Ok(())
+        }
     }
 
     /// Poison the window manager, causing it to die promptly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,9 @@ impl<Conn> OxWM<Conn> {
                 ButtonRelease(_) => self.drag = None,
                 ConfigureNotify(ev) => {
                     if ev.above_sibling == x11rb::NONE {
-                        self.clients.to_bottom(ev.window);
+                        self.clients.move_to_bottom(ev.window);
                     } else {
-                        self.clients.to_above(ev.window, ev.above_sibling);
+                        self.clients.move_to_above(ev.window, ev.above_sibling);
                     }
                     if let Some(ref mut st) = self.clients.get_mut(ev.window).state {
                         st.x = ev.x;
@@ -343,12 +343,12 @@ impl<Conn> OxWM<Conn> {
                 MotionNotify(ev) => {
                     let drag = self.drag.as_ref().unwrap();
                     let config = match drag.type_ {
-                        DragType::MOVE => {
+                        DragType::Move => {
                             let x = (ev.root_x - drag.x) as i32;
                             let y = (ev.root_y - drag.y) as i32;
                             ConfigureWindowAux::new().x(x).y(y)
                         }
-                        DragType::RESIZE(corner) => {
+                        DragType::Resize(corner) => {
                             let st = self.clients.get_mut(ev.event).state.as_ref().unwrap();
                             match corner {
                                 Corner::LeftTop => {
@@ -462,7 +462,7 @@ impl<Conn> OxWM<Conn> {
     fn begin_drag(&mut self, window: xproto::Window, button: xproto::Button, x: i16, y: i16) {
         let st = self.clients.get(window).state.as_ref().unwrap();
         let (type_, corner) = match button {
-            1 => (DragType::MOVE, Corner::LeftTop),
+            1 => (DragType::Move, Corner::LeftTop),
             3 => {
                 // We resize from whatever corner the pointer is
                 // closest to.
@@ -474,7 +474,7 @@ impl<Conn> OxWM<Conn> {
                     (true, false) => Corner::RightTop,
                     (true, true) => Corner::RightBottom,
                 };
-                (DragType::RESIZE(corner), corner)
+                (DragType::Resize(corner), corner)
             }
             _ => {
                 log::error!("Invalid button.");
@@ -702,9 +702,9 @@ impl Corner {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 enum DragType {
     /// A moving drag.
-    MOVE,
+    Move,
     /// A resizing drag.
-    RESIZE(Corner),
+    Resize(Corner),
 }
 
 /// The state of a window drag.

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,8 +17,8 @@ pub fn event_mask_to_u16(mask: xproto::EventMask) -> u16 {
 }
 
 /// Lookup the numeric value for a given `Keysym`'s text name, e.g. "Shift_L" -> 50
-/// Returns `None` if the given `key_name` is not the name of a valid Keysym or
-/// contains `null` values.
+/// Returns `None` if `key_name` is not the name of a valid Keysym or contains
+/// `null` values.
 pub fn keysym_from_name(key_name: &str) -> Option<xproto::Keysym> {
     let sym64: u64;
 
@@ -67,7 +67,7 @@ pub fn keysym_from_name(key_name: &str) -> Option<xproto::Keysym> {
 
 /// An FFI call to the X11 C library function for converting from Keysym names
 /// to Keysym values. This is unsafe code. 'symbol' _must_ be a pointer to a
-/// null terminated C style string such as is produced by std::ffi::Cstring.
+/// null terminated C style string such as is produced by `std::ffi::Cstring`.
 #[link(name = "X11")]
 extern "C" {
     fn XStringToKeysym(symbol_name: *const c_char) -> c_ulong;


### PR DESCRIPTION
The kill command operates on the window under the mouse cursor, rather than the currently focused window. Small bugfix to prevent OxWM from panicking when mouse is over the desktop background at the time the kill button is pressed (we're given window id = 0 in the event, which does not exist in our Clients stack)

Updated the documentation a bit.

Added tests where I could in `client.rs` and `config.rs`

We need to pick a LICENSE.