### PR TITLE
WM_SIZE_HINTS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2021 Nicholas Coltharp and James Nichols.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,17 @@ OxWM is not (currently) a reparenting WM, so you'll need to use your "kill"
 binding to close windows. You can drag windows around with mod+left mouse, and
 you can resize windows with mod+right mouse.
 
+We don't have full ICCCM compliance, but we have at least partial support for
+all of the following:
+
+- WM_PROTOCOLS
+- WM_STATE
+- WM_SIZE_HINTS
+
 Note: we currently log every single event we receive, which can seriously impact
 performance (you'll probably notice it when dragging windows). You can probably
-improve performance by redirecting the log to `/dev/null`, or by just ignoring
-it.
+improve performance by redirecting the log to `/dev/null`, or by just letting it
+go to stdout.
 
 # Testing
 
@@ -59,9 +66,9 @@ undertaking.
 # Future directions
 
 In its current state, this is essentially a toy project, so there's lots of room
-for expansion. However, we're unsatisfied with the codebase: it's quite messy.
-We've spent a lot of time thinking about how to design better fundamental
-abstractions, and fixing things will probably require a rewrite. This is not a
-crazy suggestion, since we didn't know anything about the X protocol when we
-started; knowing much more now, it should be easier to create a sound design
-from the start.
+for expansion. However, we're unsatisfied with the codebase: it's quite messy
+and not very DRY. We've spent a lot of time thinking about how to design better
+fundamental abstractions, and fixing things will probably require a rewrite.
+This is not a crazy suggestion, since we didn't know anything about the X
+protocol when we started; knowing much more now, it should be easier to create a
+sound design from the start.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,51 @@
-# Getting Started
+# OxWM: An X11 window manager in Rust
 
-You might want to have a file named `oxwm/config.toml` in your platform-specific
-configuration directory. For Linux, this is usually `~/.config/`. A sensible
-default config file might look like this:
+Authors: Nicholas Coltharp, James Nichols
+
+## Description
+
+OxWM is a small window manager for X11.
+
+X11 is (for a little while longer) the standard display system for most Unix and
+Unix-y systems, including Linux. X11 uses an asynchronous client-server model. A
+single program, the /X server/, lets client programs connect and make requests;
+e.g., configuring and displaying windows. Although clients most commonly connect
+over a Unix domain socket on the same machine, this is not a requirement;
+indeed, it is possible for a client to connect to a server over a network
+interface, allowing a program to run on one computer while displaying on another.
+
+One of the major design decisions of X11 protocol is that it provides
+"mechanism, not policy". That is, while the protocol specifies what kinds of
+requests may be made of the server and what events clients may be notified of,
+it does not specify any particular UI model. For example, a client may listen
+for a mouse click event on one of its windows, but there is no guarantee that
+the window will be on top after receiving this event.
+
+Policy is instead provided by a _window manager_. This is a client that is
+granted special privileges by the server, allowing it to intercept certain
+requests made by other clients and grant, modify, or deny them. To put this in
+concrete terms, a window manager is typically responsible for things like:
+
+- Drawing borders and title bars around windows
+- Allowing users to move and resize windows
+- Allowing users to minimize and close windows
+- Providing keyboard shortcuts for managing windows; e.g., Alt-Tab
+
+Although OxWM doesn't provide all of this functionality, I hope this gives a
+general idea of the task it needs to accomplish.
+
+X11 window managers also generally try to comply with the _Inter-Client
+Communication Conventions Manual_ (ICCCM), a set of standards specifying how X
+clients should interact with each other. This provides for things like, e.g.,
+letting a window manager know a window's title, or its preferred dimensions.
+
+## Getting Started
+
+You might want to have a configuration file. This is a file named
+`oxwm/config.toml` in your platform-specific configuration directory. (For
+Linux, this is usually `~/.config/`; i.e., your config file should be
+`~/.config/oxwm/config.toml`.) A sensible default config file might look like
+this:
 
 ```toml
 
@@ -21,8 +64,7 @@ tells OxWM that, with the modifier key pressed, pressing the `Escape` key should
 exit, and pressing `q` should immediately abort the process of the focused
 window.
 
-If you don't create this config file, one will be generated for you at the
-appropriate location.
+If you don't create a config file, one will be generated for you.
 
 After you've configured the program, you'll want to make your `~/.xinitrc` look
 something like this:
@@ -56,14 +98,17 @@ performance (you'll probably notice it when dragging windows). You can probably
 improve performance by redirecting the log to `/dev/null`, or by just letting it
 go to stdout.
 
-# Testing
+## Testing
 
 Due to the nature of the program, very little automated testing is possible (as
 far as we know). In theory, it should be possible to create a "mock" X
 connection and drive it programmatically, but this would be a substantial
 undertaking.
 
-# Future directions
+Instead, we had to resort to interactive testing: starting an X session, making
+some windows, interacting with things, and querying windows via `xprop`.
+
+## Future directions
 
 In its current state, this is essentially a toy project, so there's lots of room
 for expansion. However, we're unsatisfied with the codebase: it's quite messy

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 
 use x11rb::connection::Connection;
+use x11rb::properties::WmSizeHints;
 use x11rb::protocol::xproto;
 use x11rb::protocol::xproto::ConnectionExt as _;
 use x11rb::wrapper::ConnectionExt as _;
@@ -211,6 +212,17 @@ impl Atoms {
             }
         }
         Ok(ret)
+    }
+
+    pub(crate) fn get_wm_size_hints<Conn>(
+        &self,
+        conn: &Conn,
+        window: xproto::Window,
+    ) -> Result<WmSizeHints>
+    where
+        Conn: Connection,
+    {
+        Ok(WmSizeHints::get(conn, window, xproto::AtomEnum::WM_SIZE_HINTS)?.reply()?)
     }
 
     /// Get a window's WM_STATE property.

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,8 +42,8 @@ pub(crate) struct ClientState {
     pub(crate) wm_protocols: WmProtocols,
     /// The client's WM_STATE.
     pub(crate) wm_state: Option<WmState>,
-    /// The client's WM_SIZE_HINTS.
-    pub(crate) wm_size_hints: WmSizeHints,
+    /// The client's WM_NORMAL_HINTS.
+    pub(crate) wm_normal_hints: WmSizeHints,
 }
 
 /// Local data about the state of all top-level windows. This includes windows
@@ -148,7 +148,7 @@ impl Clients {
                 let is_viewable = attrs.map_state == xproto::MapState::VIEWABLE;
                 let wm_protocols = atoms.get_wm_protocols(conn, window)?;
                 let wm_state = atoms.get_wm_state(conn, window)?;
-                let wm_size_hints = atoms.get_wm_size_hints(conn, window)?;
+                let wm_normal_hints = atoms.get_wm_normal_hints(conn, window)?;
                 Some(ClientState {
                     x: geom.x,
                     y: geom.y,
@@ -157,7 +157,7 @@ impl Clients {
                     is_viewable,
                     wm_protocols,
                     wm_state,
-                    wm_size_hints,
+                    wm_normal_hints,
                 })
             };
             stack.push(Client { window, state })
@@ -267,7 +267,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
-            wm_size_hints: WmSizeHints::new(),
+            wm_normal_hints: WmSizeHints::new(),
         }),
     });
 
@@ -281,7 +281,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
-            wm_size_hints: WmSizeHints::new(),
+            wm_normal_hints: WmSizeHints::new(),
         }),
     });
 
@@ -295,7 +295,7 @@ fn can_remove_focused_window() {
             is_viewable: false,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
-            wm_size_hints: WmSizeHints::new(),
+            wm_normal_hints: WmSizeHints::new(),
         }),
     });
 
@@ -309,7 +309,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
-            wm_size_hints: WmSizeHints::new(),
+            wm_normal_hints: WmSizeHints::new(),
         }),
     });
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 //! Local data about the state of the X server.
 
 use x11rb::connection::Connection;
+use x11rb::properties::WmSizeHints;
 use x11rb::protocol::xproto;
 use x11rb::protocol::xproto::ConnectionExt as _;
 
@@ -8,7 +9,7 @@ use crate::atom::*;
 use crate::Result;
 
 /// Local data about a top-level window.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Client {
     /// The client window.
     pub(crate) window: xproto::Window,
@@ -25,7 +26,7 @@ impl Client {
 }
 
 /// Local data about the state of a top-level window.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct ClientState {
     /// Horizontal position.
     pub(crate) x: i16,
@@ -41,6 +42,8 @@ pub(crate) struct ClientState {
     pub(crate) wm_protocols: WmProtocols,
     /// The client's WM_STATE.
     pub(crate) wm_state: Option<WmState>,
+    /// The client's WM_SIZE_HINTS.
+    pub(crate) wm_size_hints: WmSizeHints,
 }
 
 /// Local data about the state of all top-level windows. This includes windows
@@ -57,7 +60,7 @@ pub(crate) struct ClientState {
 /// * It is an error to try to insert two clients with the same window ID.
 /// * It is an error to try to perform an operation on a window ID for which
 ///   there is no corresponding client.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Clients {
     /// The window stack.
     // It feels wrong to use a vector, since we're going to be inserting and
@@ -145,6 +148,7 @@ impl Clients {
                 let is_viewable = attrs.map_state == xproto::MapState::VIEWABLE;
                 let wm_protocols = atoms.get_wm_protocols(conn, window)?;
                 let wm_state = atoms.get_wm_state(conn, window)?;
+                let wm_size_hints = atoms.get_wm_size_hints(conn, window)?;
                 Some(ClientState {
                     x: geom.x,
                     y: geom.y,
@@ -153,6 +157,7 @@ impl Clients {
                     is_viewable,
                     wm_protocols,
                     wm_state,
+                    wm_size_hints,
                 })
             };
             stack.push(Client { window, state })
@@ -262,6 +267,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
+            wm_size_hints: WmSizeHints::new(),
         }),
     });
 
@@ -275,6 +281,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
+            wm_size_hints: WmSizeHints::new(),
         }),
     });
 
@@ -288,6 +295,7 @@ fn can_remove_focused_window() {
             is_viewable: false,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
+            wm_size_hints: WmSizeHints::new(),
         }),
     });
 
@@ -301,6 +309,7 @@ fn can_remove_focused_window() {
             is_viewable: true,
             wm_protocols: WmProtocols::new(),
             wm_state: None,
+            wm_size_hints: WmSizeHints::new(),
         }),
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ impl<Conn> OxWM<Conn> {
                                     state: WmStateState::Withdrawn,
                                     icon: x11rb::NONE,
                                 }),
+                                wm_size_hints: self.atoms.get_wm_size_hints(&self.conn, window)?,
                             })
                         },
                     });
@@ -430,6 +431,14 @@ impl<Conn> OxWM<Conn> {
                             .as_mut()
                             .unwrap()
                             .wm_state = self.atoms.get_wm_state(&self.conn, window)?;
+                    } else if ev.atom == xproto::AtomEnum::WM_SIZE_HINTS.into() {
+                        log::debug!("Updating WM_SIZE_HINTS.");
+                        self.clients
+                            .get_mut(window)
+                            .state
+                            .as_mut()
+                            .unwrap()
+                            .wm_size_hints = self.atoms.get_wm_size_hints(&self.conn, window)?
                     } else {
                         log::warn!("Ignoring.");
                     }


### PR DESCRIPTION
Adds support for WM_NORMAL_HINTS. This should have the following observable effects:
- Clients can now specify preferred min/max dimensions, and we should prefer those dimensions over our default min/max dimensions.
- Clients can now specify a size increment, so that resizing only happens in a certain unit. This works when resizing `gnome-terminal` from the bottom right (problems happen with the other corners, but I think that's either `gnome-terminal` behaving weird or `gnome-terminal` expecting us to honor some spec that we haven't yet implemented).

This also updates the documentation and the README, and it adds a license. I don't have strong opinions about the license; I just chose Bart's suggestion. Feel free to make changes to any of this.